### PR TITLE
Update module.info for dependency typo

### DIFF
--- a/module.info
+++ b/module.info
@@ -1,5 +1,5 @@
 Name: Azure
 Version: 0.6.3
-Depends: director>=1.3.0
+Depends: director (>=1.3.0)
 Description: Azure Cloud module for Icinga Web 2
  This module provides an Azure import source for Icinga Director


### PR DESCRIPTION
The dependency could not be resolved correctly and it was shown that "director>=1.3.0" was not installed.